### PR TITLE
Implement our own caching

### DIFF
--- a/next-app/pages/index.js
+++ b/next-app/pages/index.js
@@ -114,14 +114,14 @@ export default function Home() {
   function formatUnixTimestamp(timestamp) {
     const date = new Date(Number(timestamp))
     const options = {
-      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone, // Use the local timezone
       weekday: "short",
       month: "short",
       day: "2-digit",
       year: "numeric",
       hour: "2-digit",
       minute: "2-digit",
-      hour12: false,
+      hour12: false, // 24-hour format
     }
     return new Intl.DateTimeFormat("en-US", options).format(date)
   }
@@ -132,7 +132,7 @@ export default function Home() {
         direction="column"
         align="center"
         p={4}
-        bg="#1a1a2e"
+        bg="#1a1a2e" // Dark purple background
         minHeight="100vh"
         color="white"
       >

--- a/next-app/pages/index.js
+++ b/next-app/pages/index.js
@@ -101,7 +101,6 @@ export default function Home() {
 
       if (cachedRandomMarket) {
         setRandomMarket(cachedRandomMarket)
-        fetchMarkets()
         return
       }
 
@@ -115,8 +114,6 @@ export default function Home() {
       const jsonData = JSON.parse(result?.Messages[0]?.Data)
       setRandomMarket(jsonData)
       cacheService.set(CACHE_KEY_RANDOM, jsonData, FIVE_MINUTES)
-
-      fetchMarkets()
     } catch (error) {
       console.error("Error fetching random market:", error)
     } finally {

--- a/next-app/pages/index.js
+++ b/next-app/pages/index.js
@@ -83,7 +83,7 @@ export default function Home() {
       
       if (cachedRandomMarket) {
         setRandomMarket(cachedRandomMarket)
-        fetchMarkets(1)
+        fetchMarkets()
         return
       }
 
@@ -98,7 +98,7 @@ export default function Home() {
       setRandomMarket(jsonData)
       cacheService.set(CACHE_KEY_RANDOM, jsonData, FIVE_MINUTES)
       
-      await fetchMarkets(1)
+      fetchMarkets()
     } catch (error) {
       console.error('Error fetching random market:', error)
     } finally {

--- a/next-app/services/CacheService.js
+++ b/next-app/services/CacheService.js
@@ -1,0 +1,51 @@
+class CacheService {
+  constructor(defaultExpiry = 5 * 60 * 1000) {
+    this.defaultExpiry = defaultExpiry
+  }
+
+  set(key, data, expiryInMs = this.defaultExpiry) {
+    const item = {
+      data,
+      timestamp: new Date().getTime(),
+      expiry: expiryInMs,
+    }
+    localStorage.setItem(key, JSON.stringify(item))
+  }
+
+  get(key) {
+    const item = localStorage.getItem(key)
+    if (!item) return null
+
+    const { data, timestamp, expiry } = JSON.parse(item)
+    const now = new Date().getTime()
+
+    // Check if the data has expired
+    if (now - timestamp > expiry) {
+      this.remove(key)
+      return null
+    }
+
+    return data
+  }
+
+  remove(key) {
+    localStorage.removeItem(key)
+  }
+
+  clear() {
+    localStorage.clear()
+  }
+
+  // Optional: Get time until expiry in seconds
+  getTimeToExpiry(key) {
+    const item = localStorage.getItem(key)
+    if (!item) return 0
+
+    const { timestamp, expiry } = JSON.parse(item)
+    const now = new Date().getTime()
+    const timeLeft = expiry - (now - timestamp)
+    return Math.max(0, Math.floor(timeLeft / 1000))
+  }
+}
+
+export const cacheService = new CacheService()


### PR DESCRIPTION
In this PR, I decided to use `useCallback` for our fetch methods for Memoization and Performance since useCallback memoizes (caches) a function between re-renders. This is will help us a lot since we are calling our fetch methods in `useEffect`.

Advantages of this approach:

- Data persists through page reloads because it uses localStorage
- Instant initial render on reload since data is loaded from localStorage
- Complete control over cache invalidation (we set 5 minutes)
- Simpler setup - just two files
- No additional dependencies
- Smaller bundle size

React Query Disadvantages:
- By default, data is lost on page reload as it uses in-memory cache
- Needs additional setup for persistence through page reloads:
- More features but higher complexity

Decided to create our own caching for the reason that at initial load sometimes the node takes time to respond and if use react query data is lost on page reload as it uses in-memory cache.

